### PR TITLE
fix: add print flag to subcommand and set default behavior

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,45 +33,46 @@ use std::fs;
 use std::fs::create_dir_all;
 use std::io;
 
-use clap::{Arg, ArgMatches, Command, ValueHint};
+use clap::{Arg, ArgAction, ArgMatches, Command, ValueHint};
 use clap_complete::Shell;
 
 /// Add the `complete` subcommand to your [`Command`].
 #[must_use]
 pub fn add_subcommand(command: Command) -> Command {
     #[allow(clippy::let_and_return)] // cfg
-    let c = command.subcommand(
-        Command::new("complete").arg(
-            Arg::new("shell")
-                .num_args(1)
-                .short('s')
-                .long("shell")
-                .help("Explicitly choose which shell to output.")
-                .value_hint(ValueHint::Other),
-        ),
+    let sub_c = Command::new("complete").arg(
+        Arg::new("shell")
+            .num_args(1)
+            .short('s')
+            .long("shell")
+            .help("Explicitly choose which shell to output.")
+            .value_hint(ValueHint::Other),
     );
 
     #[cfg(any(unix, target_os = "redox"))]
     {
-        c.arg(Arg::new("print").short('p').long("print").help(
-            "Print the shell completion to stdout instead of writing to default file.\n\
+        command.subcommand(
+            sub_c
+                .arg(Arg::new("print").short('p').long("print").action(clap::ArgAction::SetTrue).help(
+                    "Print the shell completion to stdout instead of writing to default file.\n\
             Does nothing when using shells for which \
             the installation location isn't implemented.",
-        ))
-        .about(
-            "Generate completions for the detected/selected shell and \
+                ))
+                .about(
+                    "Generate completions for the detected/selected shell and \
             put the completions in appropriate directories.\n\
             Currently supports Fish, Bash, Zsh, Elvish, and PowerShell. \
             Fish, Bash, and Zsh are installed \
             automatically (when not using the --print flag).",
+                )
         )
     }
     #[cfg(not(any(unix, target_os = "redox")))]
     {
-        c.about(
+        command.subcommand(sub_c.about(
             "Generate completions for the detected/selected shell. \
             Currently supports Fish, Bash, Zsh, Elvish, and PowerShell.",
-        )
+        ))
     }
 }
 /// Check the [`ArgMatches`] for the subcommand added by [`add_subcommand`].


### PR DESCRIPTION
Hi @Icelk , thank you for creating such a helpful tool!
I encountered an error when running the example, so I fixed it. I would appreciate it if you could take a look.

### Summary of Fixes

First, I encountered following error at `clap_autocomplete/src/lib.rs:118:24`:
```
Mismatch between definition and access of print. Unknown argument or group id.  Make sure you are using the argument id and not the short or long flags
```
So, I modified the `print` flag to be added to the `complete` subcommand.

Second, the following error occurred at `clap_builder-4.5.20/src/parser/matches/arg_matches.rs:181:17`:
```
arg print's ArgAction should be one of SetTrue, SetFalse which should provide a default
```
To fix this, I added default behavior by using `.action(clap::ArgAction::SetTrue)` for the `print` arg (this means when the flag is set, it will be treated as `true`).

### Clap Version:
4.5.20